### PR TITLE
logic fix: get_servers()

### DIFF
--- a/connect_vpn.sh
+++ b/connect_vpn.sh
@@ -1,1 +1,1 @@
-sudo openvpn OVPN/us570.nordvpn.com.tcp443.ovpn
+sudo openvpn OVPN/us571.nordvpn.com.tcp443.ovpn


### PR DESCRIPTION
Rearranged logic as such: 

1. The first step is now `get_servers()`, which does the following (pseudocode):
2. Look for `.ovpn` matches in `./OVPN/`
3. If none, call `update_servers()`
4. Look for `.ovpn` matches again
5. `if matches==None: raise Exception`
6. `else: return server_matches` --> `threadPool(servers)`
